### PR TITLE
sast python 3.12 fix

### DIFF
--- a/modules/codebuild/buildspecs/sast.yml
+++ b/modules/codebuild/buildspecs/sast.yml
@@ -4,7 +4,7 @@ phases:
 
   install:
     runtime-versions:
-       python: latest
+       python: 3.12
     commands:
       - cd /usr/bin
       - yum install -y yum-utils


### PR DESCRIPTION
*Issue #:* https://github.com/aws-samples/aws-terraform-pipeline/issues/7

- Fix sast python to 3.12
